### PR TITLE
Apply grid normalization

### DIFF
--- a/pineappl_py/src/grid.rs
+++ b/pineappl_py/src/grid.rs
@@ -465,4 +465,14 @@ impl PyGrid {
             })
             .collect()
     }
+
+    /// Scale all subgrids.
+    ///
+    /// Parameters
+    /// ----------
+    /// factor : float
+    ///     scalar factor by which scaling
+    pub fn scale(&mut self, factor: f64) {
+        self.grid.scale(factor);
+    }
 }


### PR DESCRIPTION
Hi @cschwan, as you know from #89 we are dealing with normalizations, and I proposed to skip `pineappl remap` and write instead something in python.

The idea is:
1. load the grid
2. apply normalization
3. dump the grid

Nevertheless, point 2 is not that easy, so I tried to figure a way out of it, as easy as possible.

I had a look inside `pineappl remap`, and I found that you use `BinRemapper` to apply normalization:
https://github.com/N3PDF/pineappl/blob/32e63c92cd9ea8358d6e193e068a9ee33d917979/pineappl_cli/src/remap.rs#L155-L161
and this is the only place where the CLI argument `norm` appears.

So my idea for point 2 would be:
1. get the remapper (`grid.more_members.upgrade()` should guarantee is available)
2. copy the limits
3. copy normalizations and multiply by norm 
4. create a new `BinRemapper`
5. set the new remapper

Unfortunately, I noticed the `remapper` inside the `more_members` is an option, so it might not be available, then: what should I do in the case?

Moreover, I would need to implement a getter for `bin_remapper` in python, and before even in `pineappl` crate. Then I was wondering:
- should I implement the getter and do as above?
- or should we make the `normalize`/`renormalize` a method of `Grid` directly inside `pineappl`?

P.S.: I needed a commit to open the PR, but I had nothing to commit, so the moment we start I'll just squash it and remove the empty `help` file
