### PR TITLE
Support different muf2/x1/x2 grid values

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,2 @@
+github_checks:
+  annotations: false

--- a/pineappl/src/grid.rs
+++ b/pineappl/src/grid.rs
@@ -1482,7 +1482,7 @@ impl Grid {
                                 .grid_axes
                                 .x_grid
                                 .iter()
-                                .position(|xi| approx_eq!(f64, xi, x, ulps = 64))
+                                .position(|xi| approx_eq!(f64, *xi, *x, ulps = 64))
                                 .unwrap_or_else(|| unreachable!())
                         })
                         .collect();
@@ -1494,7 +1494,7 @@ impl Grid {
                                 .grid_axes
                                 .x_grid
                                 .iter()
-                                .position(|xi| approx_eq!(f64, xi, x, ulps = 64))
+                                .position(|xi| approx_eq!(f64, *xi, *x, ulps = 64))
                                 .unwrap_or_else(|| unreachable!())
                         })
                         .collect();

--- a/pineappl/src/grid.rs
+++ b/pineappl/src/grid.rs
@@ -1298,9 +1298,9 @@ impl Grid {
         }
 
         muf2_grid.sort_by(|a, b| a.partial_cmp(b).unwrap_or_else(|| unreachable!()));
-        muf2_grid.dedup();
+        muf2_grid.dedup_by(|a, b| approx_eq!(f64, *a, *b, ulps = 32));
         x_grid.sort_by(|a, b| a.partial_cmp(b).unwrap_or_else(|| unreachable!()));
-        x_grid.dedup();
+        x_grid.dedup_by(|a, b| approx_eq!(f64, *a, *b, ulps = 32));
 
         Some(GridAxes {
             x_grid,

--- a/pineappl/src/grid.rs
+++ b/pineappl/src/grid.rs
@@ -1329,7 +1329,6 @@ impl Grid {
 
         assert_eq!(dim[0], eko_info.grid_axes.muf2_grid.len());
         assert_eq!(dim[1], eko_info.target_pids.len());
-        assert_eq!(dim[2], eko_info.target_x_grid.len());
         assert_eq!(dim[3], eko_info.grid_axes.pids.len());
         assert_eq!(dim[4], eko_info.grid_axes.x_grid.len());
 

--- a/pineappl/src/grid.rs
+++ b/pineappl/src/grid.rs
@@ -1298,9 +1298,9 @@ impl Grid {
         }
 
         muf2_grid.sort_by(|a, b| a.partial_cmp(b).unwrap_or_else(|| unreachable!()));
-        muf2_grid.dedup_by(|a, b| approx_eq!(f64, *a, *b, ulps = 32));
+        muf2_grid.dedup_by(|a, b| approx_eq!(f64, *a, *b, ulps = 64));
         x_grid.sort_by(|a, b| a.partial_cmp(b).unwrap_or_else(|| unreachable!()));
-        x_grid.dedup_by(|a, b| approx_eq!(f64, *a, *b, ulps = 32));
+        x_grid.dedup_by(|a, b| approx_eq!(f64, *a, *b, ulps = 64));
 
         Some(GridAxes {
             x_grid,

--- a/pineappl/src/grid.rs
+++ b/pineappl/src/grid.rs
@@ -1330,7 +1330,6 @@ impl Grid {
         assert_eq!(dim[0], eko_info.grid_axes.muf2_grid.len());
         assert_eq!(dim[1], eko_info.target_pids.len());
         assert_eq!(dim[3], eko_info.grid_axes.pids.len());
-        assert_eq!(dim[4], eko_info.grid_axes.x_grid.len());
 
         // swap axes around to optimize convolution
         let operator = operator.permuted_axes([3, 1, 4, 0, 2]);

--- a/pineappl/src/grid.rs
+++ b/pineappl/src/grid.rs
@@ -1482,7 +1482,7 @@ impl Grid {
                                 .grid_axes
                                 .x_grid
                                 .iter()
-                                .position(|xi| xi == x)
+                                .position(|xi| approx_eq!(f64, xi, x, ulps = 64))
                                 .unwrap_or_else(|| unreachable!())
                         })
                         .collect();
@@ -1494,7 +1494,7 @@ impl Grid {
                                 .grid_axes
                                 .x_grid
                                 .iter()
-                                .position(|xi| xi == x)
+                                .position(|xi| approx_eq!(f64, xi, x, ulps = 64))
                                 .unwrap_or_else(|| unreachable!())
                         })
                         .collect();
@@ -1509,7 +1509,9 @@ impl Grid {
                             .grid_axes
                             .muf2_grid
                             .iter()
-                            .position(|&q2| q2 == eko_info.xir * eko_info.xir * scale)
+                            .position(|&q2| {
+                                approx_eq!(f64, q2, eko_info.xir * eko_info.xir * scale, ulps = 64)
+                            })
                             .unwrap_or_else(|| {
                                 panic!(
                                     "Couldn't find q2: {:?} with xir: {:?} and muf2_grid: {:?}",
@@ -1543,7 +1545,7 @@ impl Grid {
                             .grid_axes
                             .muf2_grid
                             .iter()
-                            .position(|&q2| q2 == src_q2)
+                            .position(|&q2| approx_eq!(f64, q2, src_q2, ulps = 64))
                             .unwrap()
                     })
                     .collect();


### PR DESCRIPTION
This branch relaxes the requirements on `FkTables`, which before required the same `x1` and `x2` grid x values, if both of the initial states are hadronic. The method `Grid::axes` has been rewritten such that it allows for this case, and only checks if across the luminosities, but for the same order and bin the `x1` grids agree with each other and separately that the `x2` grids agree with each other. In `Grid::convolute_eko` this requires a translation of source-`x` values of the grid to the source-`x` values of the operator. This generalizes the case in which they were inversely sorted to each other.

This PR closes #92.

CC @AleCandido @felixhekhorn we need to test this, but I'd like to avoid creating a new Python API release for this branch. Specifically we need to check that
1) it doesn't introduces a regression, meaning that grids where the `x1` and `x2` values are all the same are still properly evolved,
2) that grids where `x1` and `x2` values are different are now working as well.