### PR TITLE
Speedup `Grid::convolute_eko`

### DIFF
--- a/pineappl/src/grid.rs
+++ b/pineappl/src/grid.rs
@@ -1608,12 +1608,14 @@ impl Grid {
 
                         // if `op1` and `op2` below are zero there's no work to do
                         // TODO: ideally we change the for loops instead of vetoing here
-                        if (has_pdf1 && !non_zero_pid_indices
-                            .iter()
-                            .any(|&tuple| tuple == (tgt_pid1_idx, src_pid1_idx)))
-                            || (has_pdf2 && !non_zero_pid_indices
+                        if (has_pdf1
+                            && !non_zero_pid_indices
                                 .iter()
-                                .any(|&tuple| tuple == (tgt_pid2_idx, src_pid2_idx)))
+                                .any(|&tuple| tuple == (tgt_pid1_idx, src_pid1_idx)))
+                            || (has_pdf2
+                                && !non_zero_pid_indices
+                                    .iter()
+                                    .any(|&tuple| tuple == (tgt_pid2_idx, src_pid2_idx)))
                         {
                             continue;
                         }

--- a/pineappl/src/grid.rs
+++ b/pineappl/src/grid.rs
@@ -1608,10 +1608,10 @@ impl Grid {
 
                         // if `op1` and `op2` below are zero there's no work to do
                         // TODO: ideally we change the for loops instead of vetoing here
-                        if non_zero_pid_indices
+                        if !non_zero_pid_indices
                             .iter()
                             .any(|&tuple| tuple == (tgt_pid1_idx, src_pid1_idx))
-                            || non_zero_pid_indices
+                            || !non_zero_pid_indices
                                 .iter()
                                 .any(|&tuple| tuple == (tgt_pid2_idx, src_pid2_idx))
                         {

--- a/pineappl/src/grid.rs
+++ b/pineappl/src/grid.rs
@@ -1440,6 +1440,39 @@ impl Grid {
             })
             .collect();
 
+        // the x1 and x2 grid values are the same across all non-zero subgrids
+        let first_non_zero_grid = self
+            .subgrids
+            .iter()
+            .filter(|subgrid| !subgrid.is_empty())
+            .next()
+            .unwrap_or_else(|| unreachable!());
+        // source x1/x2 grid might differ and be differently sorted than the operator
+        let x1_grid: Vec<_> = first_non_zero_grid
+            .x1_grid()
+            .iter()
+            .map(|x| {
+                eko_info
+                    .grid_axes
+                    .x_grid
+                    .iter()
+                    .position(|xi| approx_eq!(f64, *xi, *x, ulps = 64))
+                    .unwrap_or_else(|| unreachable!())
+            })
+            .collect();
+        let x2_grid: Vec<_> = first_non_zero_grid
+            .x2_grid()
+            .iter()
+            .map(|x| {
+                eko_info
+                    .grid_axes
+                    .x_grid
+                    .iter()
+                    .position(|xi| approx_eq!(f64, *xi, *x, ulps = 64))
+                    .unwrap_or_else(|| unreachable!())
+            })
+            .collect();
+
         // iterate over all bins, which are mapped one-to-one from the target to the source grid
         for bin in 0..self.bin_info().bins() {
             // iterate over the source grid luminosities
@@ -1487,32 +1520,6 @@ impl Grid {
                     };
 
                     let src_subgrid = &self.subgrids[[order, bin, src_lumi]];
-
-                    // source x1/x2 grid might differ and be differently sorted than the operator
-                    let x1_grid: Vec<_> = src_subgrid
-                        .x1_grid()
-                        .iter()
-                        .map(|x| {
-                            eko_info
-                                .grid_axes
-                                .x_grid
-                                .iter()
-                                .position(|xi| approx_eq!(f64, *xi, *x, ulps = 64))
-                                .unwrap_or_else(|| unreachable!())
-                        })
-                        .collect();
-                    let x2_grid: Vec<_> = src_subgrid
-                        .x2_grid()
-                        .iter()
-                        .map(|x| {
-                            eko_info
-                                .grid_axes
-                                .x_grid
-                                .iter()
-                                .position(|xi| approx_eq!(f64, *xi, *x, ulps = 64))
-                                .unwrap_or_else(|| unreachable!())
-                        })
-                        .collect();
 
                     for ((iq2, ix1, ix2), &value) in src_subgrid.iter() {
                         let scale = src_subgrid.mu2_grid()[iq2].fac;

--- a/pineappl/src/grid.rs
+++ b/pineappl/src/grid.rs
@@ -1429,6 +1429,17 @@ impl Grid {
             "[{elapsed_precise}] {bar:50.cyan/blue} {pos:>7}/{len:7} - ETA: {eta_precise} {msg}",
         ));
 
+        // which (tgt_pid, src_pid) tuples are non-zero in general?
+        let non_zero_pid_indices: Vec<_> = (0..operator.dim().0)
+            .cartesian_product(0..operator.dim().1)
+            .filter(|&(tgt_pid_idx, src_pid_idx)| {
+                operator
+                    .slice(s![tgt_pid_idx, src_pid_idx, .., .., ..])
+                    .iter()
+                    .any(|&value| value != 0.0)
+            })
+            .collect();
+
         // iterate over all bins, which are mapped one-to-one from the target to the source grid
         for bin in 0..self.bin_info().bins() {
             // iterate over the source grid luminosities
@@ -1594,6 +1605,18 @@ impl Grid {
                         } else {
                             0
                         };
+
+                        // if `op1` and `op2` below are zero there's no work to do
+                        // TODO: ideally we change the for loops instead of vetoing here
+                        if non_zero_pid_indices
+                            .iter()
+                            .any(|&tuple| tuple == (tgt_pid1_idx, src_pid1_idx))
+                            || non_zero_pid_indices
+                                .iter()
+                                .any(|&tuple| tuple == (tgt_pid2_idx, src_pid2_idx))
+                        {
+                            continue;
+                        }
 
                         // create target subgrid
                         let mut tgt_array =

--- a/pineappl/src/grid.rs
+++ b/pineappl/src/grid.rs
@@ -1608,12 +1608,12 @@ impl Grid {
 
                         // if `op1` and `op2` below are zero there's no work to do
                         // TODO: ideally we change the for loops instead of vetoing here
-                        if !non_zero_pid_indices
+                        if (has_pdf1 && !non_zero_pid_indices
                             .iter()
-                            .any(|&tuple| tuple == (tgt_pid1_idx, src_pid1_idx))
-                            || !non_zero_pid_indices
+                            .any(|&tuple| tuple == (tgt_pid1_idx, src_pid1_idx)))
+                            || (has_pdf2 && !non_zero_pid_indices
                                 .iter()
-                                .any(|&tuple| tuple == (tgt_pid2_idx, src_pid2_idx))
+                                .any(|&tuple| tuple == (tgt_pid2_idx, src_pid2_idx)))
                         {
                             continue;
                         }


### PR DESCRIPTION
The runtime for `Grid::convolute_eko` for double-hadronic grids is, unfortunately, quite long, of the order of 10-15 minutes for a typical case. I'm convinced that we can improve the runtime, and I have at least two ideas how:

1. Eliminate zeros of the EKO early. Commit 6aa3ba4668df63d22b41b0c82ee59e4e65df5280 checks, for all source- and target-PID tuples, whether the operator is non-zero by going through all its elements once. For instance, in many of the grids we have a photon as an initial state, but often we ignore the PDF at the fitting scale and so we can skip everything that has a photon. This is also true for top and anti-top quarks, and possibly for other quark flavour as well.
2. The actual convolution can be rewritten as a loop over the different mu2 values, each performing the following operation in the general case where there are two hadronic initial states: `(FK)_ij = sum_k O_il (G_lm)_k O_mj`, so that we could leverage fast linear algebra libraries.

However, we need to test and benchmark this.