### PR TITLE
Support native pathlike objects

### DIFF
--- a/pineappl_py/pineappl/fk_table.py
+++ b/pineappl_py/pineappl/fk_table.py
@@ -24,7 +24,7 @@ class FkTable(PyWrapper):
 
         Parameters
         ----------
-            path : str
+            path : pathlike
                 file path
 
         Returns

--- a/pineappl_py/pineappl/grid.py
+++ b/pineappl_py/pineappl/grid.py
@@ -291,7 +291,7 @@ class Grid(PyWrapper):
 
         Parameters
         ----------
-            path : str
+            path : pathlike
                 file path
 
         Returns

--- a/pineappl_py/src/fk_table.rs
+++ b/pineappl_py/src/fk_table.rs
@@ -1,12 +1,15 @@
-use numpy::{IntoPyArray, PyArray1, PyArray4};
 use pineappl::fk_table::FkTable;
 use pineappl::grid::Grid;
 use pineappl::lumi::LumiCache;
+
+use numpy::{IntoPyArray, PyArray1, PyArray4};
 use pyo3::prelude::*;
+
 use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::fs::File;
 use std::io::BufReader;
+use std::path::PathBuf;
 
 /// PyO3 wrapper to :rustdoc:`pineappl::fk_table::FkTable <fk_table/struct.FkTable.html>`
 ///
@@ -20,7 +23,7 @@ pub struct PyFkTable {
 #[pymethods]
 impl PyFkTable {
     #[staticmethod]
-    pub fn read(path: &str) -> Self {
+    pub fn read(path: PathBuf) -> Self {
         Self {
             fk_table: FkTable::try_from(
                 Grid::read(BufReader::new(File::open(path).unwrap())).unwrap(),
@@ -150,7 +153,7 @@ impl PyFkTable {
     /// ----------
     ///     path : str
     ///         file path
-    pub fn write(&self, path: &str) {
+    pub fn write(&self, path: PathBuf) {
         self.fk_table.write(File::create(path).unwrap()).unwrap();
     }
 
@@ -162,7 +165,7 @@ impl PyFkTable {
     /// ----------
     ///     path : str
     ///         file path
-    pub fn write_lz4(&self, path: &str) {
+    pub fn write_lz4(&self, path: PathBuf) {
         self.fk_table
             .write_lz4(File::create(path).unwrap())
             .unwrap();

--- a/pineappl_py/src/grid.rs
+++ b/pineappl_py/src/grid.rs
@@ -12,6 +12,7 @@ use numpy::{IntoPyArray, PyArray1};
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::BufReader;
+use std::path::PathBuf;
 
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
@@ -357,7 +358,7 @@ impl PyGrid {
     ///     PyGrid :
     ///         grid
     #[staticmethod]
-    pub fn read(path: &str) -> Self {
+    pub fn read(path: PathBuf) -> Self {
         Self::new(Grid::read(BufReader::new(File::open(path).unwrap())).unwrap())
     }
 
@@ -369,7 +370,7 @@ impl PyGrid {
     /// ----------
     ///     path : str
     ///         file path
-    pub fn write(&self, path: &str) {
+    pub fn write(&self, path: PathBuf) {
         self.grid.write(File::create(path).unwrap()).unwrap();
     }
 
@@ -379,7 +380,7 @@ impl PyGrid {
     /// ----------
     ///     path : str
     ///         file path
-    pub fn write_lz4(&self, path: &str) {
+    pub fn write_lz4(&self, path: PathBuf) {
         self.grid.write_lz4(File::create(path).unwrap()).unwrap();
     }
 
@@ -396,7 +397,7 @@ impl PyGrid {
     /// ----
     /// For a current limitation with the implementation of the bound object `Grid` is not possible
     /// to operate with two `Grid`s in memory, since is not possible to pass a `Grid` by argument
-    pub fn merge_from_file(&mut self, path: &str) -> PyResult<()> {
+    pub fn merge_from_file(&mut self, path: PathBuf) -> PyResult<()> {
         match self.grid.merge(Self::read(path).grid) {
             Ok(()) => Ok(()),
             Err(x) => Err(PyValueError::new_err(format!("{:?}", x))),

--- a/pineappl_py/tests/test_grid.py
+++ b/pineappl_py/tests/test_grid.py
@@ -28,7 +28,7 @@ class TestGrid:
         assert isinstance(g.raw, pineappl.pineappl.PyGrid)
         # orders
         assert len(g.orders()) == 1
-        assert g.orders()[0].as_tuple() == (3,0,0,0)
+        assert g.orders()[0].as_tuple() == (3, 0, 0, 0)
 
     def test_set_subgrid(self):
         g = self.fake_grid()
@@ -57,28 +57,28 @@ class TestGrid:
     def test_set_key_value(self):
         g = self.fake_grid()
         g.set_key_value("bla", "blub")
-        g.set_key_value("\"", "'")
+        g.set_key_value('"', "'")
         g.set_key_value("äöü", "ß\\")
 
     def test_bins(self):
         g = self.fake_grid()
         # 1D
         normalizations = [1.0] * 2
-        limits = [(1,1),(2,2)]
+        limits = [(1, 1), (2, 2)]
         remapper = pineappl.bin.BinRemapper(normalizations, limits)
         g.set_remapper(remapper)
         assert g.bin_dimensions() == 1
-        np.testing.assert_allclose(g.bin_left(0), [1,2])
-        np.testing.assert_allclose(g.bin_right(0), [1,2])
+        np.testing.assert_allclose(g.bin_left(0), [1, 2])
+        np.testing.assert_allclose(g.bin_right(0), [1, 2])
         # 2D
-        limits = [(1,2),(2,3),(2,4),(3,5)]
+        limits = [(1, 2), (2, 3), (2, 4), (3, 5)]
         remapper = pineappl.bin.BinRemapper(normalizations, limits)
         g.set_remapper(remapper)
         assert g.bin_dimensions() == 2
-        np.testing.assert_allclose(g.bin_left(0), [1,2])
-        np.testing.assert_allclose(g.bin_right(0), [2,4])
-        np.testing.assert_allclose(g.bin_left(1), [2,3])
-        np.testing.assert_allclose(g.bin_right(1), [3,5])
+        np.testing.assert_allclose(g.bin_left(0), [1, 2])
+        np.testing.assert_allclose(g.bin_right(0), [2, 4])
+        np.testing.assert_allclose(g.bin_left(1), [2, 3])
+        np.testing.assert_allclose(g.bin_right(1), [3, 5])
 
     def test_convolute_with_one(self):
         g = self.fake_grid()
@@ -93,9 +93,18 @@ class TestGrid:
             [1.0],
         )
         g.set_subgrid(0, 0, 0, subgrid)
-        np.testing.assert_allclose(g.convolute_with_one(2212, lambda pid,x,q2: 0., lambda q2: 0.), [0.]*2)
-        np.testing.assert_allclose(g.convolute_with_one(2212, lambda pid,x,q2: 1, lambda q2: 1.), [5e6/9999,0.])
-        np.testing.assert_allclose(g.convolute_with_one(2212, lambda pid,x,q2: 1, lambda q2: 2.), [2**3 * 5e6/9999,0.])
+        np.testing.assert_allclose(
+            g.convolute_with_one(2212, lambda pid, x, q2: 0.0, lambda q2: 0.0),
+            [0.0] * 2,
+        )
+        np.testing.assert_allclose(
+            g.convolute_with_one(2212, lambda pid, x, q2: 1, lambda q2: 1.0),
+            [5e6 / 9999, 0.0],
+        )
+        np.testing.assert_allclose(
+            g.convolute_with_one(2212, lambda pid, x, q2: 1, lambda q2: 2.0),
+            [2 ** 3 * 5e6 / 9999, 0.0],
+        )
 
     def test_axes(self):
         g = self.fake_grid()
@@ -105,7 +114,7 @@ class TestGrid:
         vs = np.random.rand(len(xs))
         subgrid = pineappl.import_only_subgrid.ImportOnlySubgridV1(
             vs[np.newaxis, :, np.newaxis],
-            [90.],
+            [90.0],
             xs,
             [1.0],
         )
@@ -113,7 +122,7 @@ class TestGrid:
         vs2 = np.random.rand(len(xs))
         subgrid = pineappl.import_only_subgrid.ImportOnlySubgridV1(
             vs2[np.newaxis, :, np.newaxis],
-            [100.],
+            [100.0],
             xs,
             [1.0],
         )
@@ -123,31 +132,27 @@ class TestGrid:
 
         np.testing.assert_allclose(ei[0], xs)
         np.testing.assert_allclose(ei[1], [])
-        np.testing.assert_allclose(ei[2], [90., 100.])
+        np.testing.assert_allclose(ei[2], [90.0, 100.0])
 
     def test_io(self, tmp_path):
         g = self.fake_grid()
         p = tmp_path / "test.pineappl"
         p.write_text("")
         g.write(str(p))
-        gg = pineappl.grid.Grid.read(str(p))
+        gg = pineappl.grid.Grid.read(p)
         assert isinstance(gg, pineappl.grid.Grid)
+        ggg = pineappl.grid.Grid.read(str(p))
 
     def test_convolute_eko(self):
         g = self.fake_grid()
         fake_eko = {
-            "q2_ref": 1.,
+            "q2_ref": 1.0,
             "targetpids": [1],
-            "targetgrid": [.1,1.],
+            "targetgrid": [0.1, 1.0],
             "inputpids": [1],
-            "inputgrid": [.1,1.],
-            "interpolation_xgrid": [.1,1.],
-            "Q2grid": {
-                90: {
-                    "operators": np.random.rand(1,2,1,2),
-                    "alphas": 1.
-                }
-            }
+            "inputgrid": [0.1, 1.0],
+            "interpolation_xgrid": [0.1, 1.0],
+            "Q2grid": {90: {"operators": np.random.rand(1, 2, 1, 2), "alphas": 1.0}},
         }
         g.set_key_value("lumi_id_types", "pdg_mc_ids")
         fk = g.convolute_eko(fake_eko)


### PR DESCRIPTION
This should close #84.

It's a tiny PR, and we can even quickly merge.
I ran existing tests, and slightly extended (sorry for the diff, but someone forgot to run `black` on unit tests).
I even tested it manually, and it's smoothly working.

Speaking of tests: maybe it might be a good chance to extend the IO related ones a bit (`write_lz4` is not tested, nor `read`, `write` and `write_lz4` for FkTables... actually almost nothing is tested of Fk).
In any case: the interface is a thin wrapper, so an extensive test suite is not that required, and we can even postpone to a more consistent tests rework.