### PR TITLE
Lists to numpy arrays in python interface

### DIFF
--- a/pineappl_py/pineappl/bin.py
+++ b/pineappl_py/pineappl/bin.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from .pineappl import PyBinRemapper
 from .utils import PyWrapper
 
@@ -8,11 +10,11 @@ class BinRemapper(PyWrapper):
 
     Parameters
     ----------
-        normalization : list(float)
+        normalizations : sequence(float)
             list with normalizations
         limits : list(tuple(float,float))
             all bin limits as a flat list
     """
 
-    def __init__(self, normalization, limits):
-        self._raw = PyBinRemapper(normalization, limits)
+    def __init__(self, normalizations, limits):
+        self._raw = PyBinRemapper(np.array(normalizations), limits)

--- a/pineappl_py/pineappl/grid.py
+++ b/pineappl_py/pineappl/grid.py
@@ -195,9 +195,9 @@ class Grid(PyWrapper):
         pdg_id,
         xfx,
         alphas,
-        order_mask=(),
-        bin_indices=(),
-        lumi_mask=(),
+        order_mask=np.array([], dtype=bool),
+        bin_indices=np.array([], dtype=np.uint64),
+        lumi_mask=np.array([], dtype=bool),
         xi=((1.0, 1.0),),
     ):
         """
@@ -268,17 +268,16 @@ class Grid(PyWrapper):
         alphas_values = [op["alphas"] for op in operators["Q2grid"].values()]
         return FkTable(
             self.raw.convolute_eko(
-                operators["q2_ref"],
-                alphas_values,
-                operators["targetpids"],
-                operators["targetgrid"],
-                operators["inputpids"],
-                operators["inputgrid"],
-                q2grid,
-                operator_grid.flatten(),
-                operator_grid.shape,
+                np.array(operators["q2_ref"]),
+                np.array(alphas_values),
+                np.array(operators["targetpids"], dtype=np.int32),
+                np.array(operators["targetgrid"]),
+                np.array(operators["inputpids"], dtype=np.int32),
+                np.array(operators["inputgrid"]),
+                np.array(q2grid, dtype=np.float64),
+                np.array(operator_grid),
                 lumi_id_types,
-                order_mask,
+                np.array(order_mask, dtype=bool),
             )
         )
 

--- a/pineappl_py/pineappl/import_only_subgrid.py
+++ b/pineappl_py/pineappl/import_only_subgrid.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from .pineappl import PyImportOnlySubgridV1
 from .utils import PyWrapper
 
@@ -8,15 +10,17 @@ class ImportOnlySubgridV1(PyWrapper):
 
     Parameters
     ----------
-        array : numpy.ndarray
+        array : numpy.ndarray(float, dim=3)
             3-dimensional subgrid content
-        q2_grid : list(float)
+        q2_grid : sequence(float)
             scale grid
-        x1_grid : list(float)
+        x1_grid : sequence(float)
             interpolation grid for :math:`x_1`
-        x2_grid : list(float)
+        x2_grid : sequence(float)
             interpolation grid for :math:`x_2`
     """
 
     def __init__(self, array, q2_grid, x1_grid, x2_grid):
-        self._raw = PyImportOnlySubgridV1(array, q2_grid, x1_grid, x2_grid)
+        self._raw = PyImportOnlySubgridV1(
+            np.array(array), np.array(q2_grid), np.array(x1_grid), np.array(x2_grid)
+        )

--- a/pineappl_py/src/bin.rs
+++ b/pineappl_py/src/bin.rs
@@ -1,5 +1,6 @@
 use pineappl::bin::BinRemapper;
 
+use numpy::PyReadonlyArray1;
 use pyo3::prelude::*;
 
 /// PyO3 wrapper to :rustdoc:`pineappl::bin::BinRemapper <bin/struct.BinRemapper.html>`
@@ -21,7 +22,7 @@ impl PyBinRemapper {
 #[pymethods]
 impl PyBinRemapper {
     #[new]
-    pub fn new_f64(normalizations: Vec<f64>, limits: Vec<(f64, f64)>) -> Self {
-        Self::new(BinRemapper::new(normalizations, limits).unwrap())
+    pub fn new_f64(normalizations: PyReadonlyArray1<f64>, limits: Vec<(f64, f64)>) -> Self {
+        Self::new(BinRemapper::new(normalizations.to_vec().unwrap(), limits).unwrap())
     }
 }

--- a/pineappl_py/src/fk_table.rs
+++ b/pineappl_py/src/fk_table.rs
@@ -54,7 +54,7 @@ impl PyFkTable {
     ///
     /// Returns
     /// -------
-    ///     np.array
+    ///     numpy.ndarray
     ///         bin normalizations
     pub fn bin_normalizations<'py>(&self, py: Python<'py>) -> &'py PyArray1<f64> {
         self.fk_table.bin_normalizations().into_pyarray(py)
@@ -81,7 +81,7 @@ impl PyFkTable {
     ///
     /// Returns
     /// -------
-    ///     list(float) :
+    ///     numpy.ndarray(float) :
     ///         left edges of bins
     pub fn bin_left<'py>(&self, dimension: usize, py: Python<'py>) -> &'py PyArray1<f64> {
         self.fk_table.bin_left(dimension).into_pyarray(py)
@@ -96,7 +96,7 @@ impl PyFkTable {
     ///
     /// Returns
     /// -------
-    ///     list(float) :
+    ///     numpy.ndarray(float) :
     ///         right edges of bins
     pub fn bin_right<'py>(&self, dimension: usize, py: Python<'py>) -> &'py PyArray1<f64> {
         self.fk_table.bin_right(dimension).into_pyarray(py)
@@ -137,7 +137,7 @@ impl PyFkTable {
     ///
     /// Returns
     /// -------
-    ///     x_grid : list(float)
+    ///     x_grid : numpy.ndarray(float)
     ///         interpolation grid
     pub fn x_grid<'py>(&self, py: Python<'py>) -> &'py PyArray1<f64> {
         self.fk_table.x_grid().into_pyarray(py)
@@ -182,7 +182,7 @@ impl PyFkTable {
     ///
     /// Returns
     /// -------
-    ///     list(float) :
+    ///     numpy.ndarray(float) :
     ///         cross sections for all bins
     pub fn convolute_with_one<'py>(
         &self,

--- a/pineappl_py/src/grid.rs
+++ b/pineappl_py/src/grid.rs
@@ -64,6 +64,11 @@ impl PyOrder {
     /// the NNLO QCD.
     ///
     /// See `pineappl` crate docs for relevant examples
+    ///
+    /// Returns
+    /// -------
+    /// numpy.ndarray(bool)
+    ///     boolean array, to be used as orders' mask
     #[staticmethod]
     pub fn create_mask<'py>(
         orders: Vec<PyRef<Self>>,
@@ -208,11 +213,11 @@ impl PyGrid {
     ///
     /// Returns
     /// -------
-    ///     x_grid: list(float)
+    ///     x_grid: numpy.ndarray(float)
     ///         interpolation grid
-    ///     pids: list(int)
+    ///     pids: numpy.ndarray(int)
     ///         particle ids
-    ///     muf2_grid : list(float)
+    ///     muf2_grid : numpy.ndarray(float)
     ///         factorization scale list
     pub fn axes<'py>(
         &self,
@@ -242,13 +247,13 @@ impl PyGrid {
     ///         lhapdf like callable with arguments `pid, x, Q2` returning x*pdf for :math:`x`-grid
     ///     alphas : callable
     ///         lhapdf like callable with arguments `Q2` returning :math:`\alpha_s`
-    ///     order_mask : list(bool)
+    ///     order_mask : numpy.ndarray(bool)
     ///         Mask for selecting specific orders. The value `True` means the corresponding order
     ///         is included. An empty list corresponds to all orders being enabled.
-    ///     bin_indices : list(int)
+    ///     bin_indices : numpy.ndarray(int)
     ///         A list with the indices of the corresponding bins that should be calculated. An
     ///         empty list means that all orders should be calculated.
-    ///     lumi_mask : list(bool)
+    ///     lumi_mask : numpy.ndarray(bool)
     ///         Mask for selecting specific luminosity channels. The value `True` means the
     ///         corresponding channel is included. An empty list corresponds to all channels being
     ///         enabled.
@@ -261,7 +266,7 @@ impl PyGrid {
     ///
     /// Returns
     /// -------
-    ///     list(float) :
+    ///     numpu.ndarray(float) :
     ///         cross sections for all bins, for each scale-variation tuple (first all bins, then
     ///         the scale variation)
     pub fn convolute_with_one<'py>(
@@ -297,24 +302,22 @@ impl PyGrid {
     /// ----------
     ///     muf2_0 : float
     ///         reference scale
-    ///     alphas : list(float)
+    ///     alphas : numpy.ndarray(float)
     ///         list with :math:`\alpha_s(Q2)` for the process scales
-    ///     pids : list(int)
+    ///     pids : numpy.ndarray(int)
     ///         sorting of the particles in the tensor
-    ///     x_grid : list(float)
+    ///     x_grid : numpy.ndarray(float)
     ///         interpolation grid
-    ///     target_pids : list(int)
+    ///     target_pids : numpy.ndarray(int)
     ///         sorting of the particles in the tensor for final FkTable
-    ///     target_x_grid : list(float)
+    ///     target_x_grid : numpy.ndarray(float)
     ///         final FKTable interpolation grid
-    ///     muf2_grid : list(float)
+    ///     muf2_grid : numpy.ndarray(float)
     ///         list of process scales
-    ///     operator_flattened : list(float)
-    ///         evolution tensor as a flat list
-    ///     operator_shape : list(int)
-    ///         shape of the evolution tensor
-    ///     additional_metadata : dict(str: str)
-    ///         further metadata
+    ///     operator : numpy.ndarray(int, rank=5)
+    ///         evolution tensor
+    ///     orders_mask: numpy.ndarray(bool)
+    ///         boolean mask to activate orders
     ///
     /// Returns
     /// -------
@@ -441,7 +444,7 @@ impl PyGrid {
     ///
     /// Returns
     /// -------
-    ///     np.array
+    ///     np.ndarray
     ///         bin normalizations
     pub fn bin_normalizations<'py>(&self, py: Python<'py>) -> &'py PyArray1<f64> {
         self.grid.bin_info().normalizations().into_pyarray(py)
@@ -458,7 +461,7 @@ impl PyGrid {
     ///
     /// Returns
     /// -------
-    ///     list(float) :
+    ///     numpy.ndarray(float) :
     ///         left edges of bins
     pub fn bin_left<'py>(&self, dimension: usize, py: Python<'py>) -> &'py PyArray1<f64> {
         self.grid.bin_info().left(dimension).into_pyarray(py)
@@ -475,7 +478,7 @@ impl PyGrid {
     ///
     /// Returns
     /// -------
-    ///     list(float) :
+    ///     numpy.ndarray(float) :
     ///         right edges of bins
     pub fn bin_right<'py>(&self, dimension: usize, py: Python<'py>) -> &'py PyArray1<f64> {
         self.grid.bin_info().right(dimension).into_pyarray(py)
@@ -513,7 +516,7 @@ impl PyGrid {
     ///
     /// Parameters
     /// ----------
-    /// bin_indices : list(int)
+    /// bin_indices : numpy.ndarray(int)
     ///     list of indices of bins to removed
     pub fn delete_bins(&mut self, bin_indices: PyReadonlyArray1<usize>) {
         self.grid.delete_bins(&bin_indices.to_vec().unwrap())

--- a/pineappl_py/src/import_only_subgrid.rs
+++ b/pineappl_py/src/import_only_subgrid.rs
@@ -1,7 +1,9 @@
 use super::subgrid::PySubgridEnum;
-use numpy::PyReadonlyArray3;
+
+use numpy::{PyReadonlyArray1, PyReadonlyArray3};
 use pineappl::import_only_subgrid::ImportOnlySubgridV1;
 use pineappl::sparse_array3::SparseArray3;
+
 use pyo3::prelude::*;
 
 /// PyO3 wrapper to :rustdoc:`pineappl::import_only_subgrid::ImportOnlySubgridV1 <import_only_subgrid/struct.ImportOnlySubgridV1.html>`
@@ -27,9 +29,9 @@ impl PyImportOnlySubgridV1 {
     #[new]
     pub fn new_import_only_subgrid(
         array: PyReadonlyArray3<f64>,
-        q2_grid: Vec<f64>,
-        x1_grid: Vec<f64>,
-        x2_grid: Vec<f64>,
+        q2_grid: PyReadonlyArray1<f64>,
+        x1_grid: PyReadonlyArray1<f64>,
+        x2_grid: PyReadonlyArray1<f64>,
     ) -> Self {
         let mut sparse_array = SparseArray3::new(q2_grid.len(), x1_grid.len(), x2_grid.len());
 
@@ -43,9 +45,9 @@ impl PyImportOnlySubgridV1 {
 
         Self::new(ImportOnlySubgridV1::new(
             sparse_array,
-            q2_grid,
-            x1_grid,
-            x2_grid,
+            q2_grid.to_vec().unwrap(),
+            x1_grid.to_vec().unwrap(),
+            x2_grid.to_vec().unwrap(),
         ))
     }
 

--- a/pineappl_py/tests/test_bin.py
+++ b/pineappl_py/tests/test_bin.py
@@ -1,12 +1,14 @@
+import numpy as np
 import pineappl
 import pytest
 
+
 class TestBinRemapper:
     def test_init(self):
-        br = pineappl.bin.BinRemapper([1], [(2, 3)])
+        br = pineappl.bin.BinRemapper(np.array([1.0]), [(2, 3)])
 
         assert isinstance(br, pineappl.bin.BinRemapper)
         assert isinstance(br.raw, pineappl.pineappl.PyBinRemapper)
-        
+
         with pytest.raises(AttributeError):
             br._bla()

--- a/pineappl_py/tests/test_grid.py
+++ b/pineappl_py/tests/test_grid.py
@@ -17,7 +17,7 @@ class TestGrid:
     def fake_grid(self):
         lumis = [pineappl.lumi.LumiEntry([(1, 21, 0.1)])]
         orders = [pineappl.grid.Order(3, 0, 0, 0)]
-        bin_limits = [1e-7, 1e-3, 1]
+        bin_limits = np.array([1e-7, 1e-3, 1])
         subgrid_params = pineappl.subgrid.SubgridParams()
         g = pineappl.grid.Grid.create(lumis, orders, bin_limits, subgrid_params)
         return g
@@ -28,7 +28,7 @@ class TestGrid:
         assert isinstance(g.raw, pineappl.pineappl.PyGrid)
         # orders
         assert len(g.orders()) == 1
-        assert g.orders()[0].as_tuple() == (3,0,0,0)
+        assert g.orders()[0].as_tuple() == (3, 0, 0, 0)
 
     def test_set_subgrid(self):
         g = self.fake_grid()
@@ -38,9 +38,9 @@ class TestGrid:
         vs = np.random.rand(len(xs))
         subgrid = pineappl.import_only_subgrid.ImportOnlySubgridV1(
             vs[np.newaxis, :, np.newaxis],
-            [90],
-            xs,
-            [1.0],
+            np.array([90.0]),
+            np.array(xs),
+            np.array([1.0]),
         )
         g.set_subgrid(0, 0, 0, subgrid)
 
@@ -57,28 +57,28 @@ class TestGrid:
     def test_set_key_value(self):
         g = self.fake_grid()
         g.set_key_value("bla", "blub")
-        g.set_key_value("\"", "'")
+        g.set_key_value('"', "'")
         g.set_key_value("äöü", "ß\\")
 
     def test_bins(self):
         g = self.fake_grid()
         # 1D
-        normalizations = [1.0] * 2
-        limits = [(1,1),(2,2)]
+        normalizations = np.array([1.0] * 2)
+        limits = [(1, 1), (2, 2)]
         remapper = pineappl.bin.BinRemapper(normalizations, limits)
         g.set_remapper(remapper)
         assert g.bin_dimensions() == 1
-        np.testing.assert_allclose(g.bin_left(0), [1,2])
-        np.testing.assert_allclose(g.bin_right(0), [1,2])
+        np.testing.assert_allclose(g.bin_left(0), [1, 2])
+        np.testing.assert_allclose(g.bin_right(0), [1, 2])
         # 2D
-        limits = [(1,2),(2,3),(2,4),(3,5)]
+        limits = [(1, 2), (2, 3), (2, 4), (3, 5)]
         remapper = pineappl.bin.BinRemapper(normalizations, limits)
         g.set_remapper(remapper)
         assert g.bin_dimensions() == 2
-        np.testing.assert_allclose(g.bin_left(0), [1,2])
-        np.testing.assert_allclose(g.bin_right(0), [2,4])
-        np.testing.assert_allclose(g.bin_left(1), [2,3])
-        np.testing.assert_allclose(g.bin_right(1), [3,5])
+        np.testing.assert_allclose(g.bin_left(0), [1, 2])
+        np.testing.assert_allclose(g.bin_right(0), [2, 4])
+        np.testing.assert_allclose(g.bin_left(1), [2, 3])
+        np.testing.assert_allclose(g.bin_right(1), [3, 5])
 
     def test_convolute_with_one(self):
         g = self.fake_grid()
@@ -88,14 +88,23 @@ class TestGrid:
         vs = xs.copy()
         subgrid = pineappl.import_only_subgrid.ImportOnlySubgridV1(
             vs[np.newaxis, :, np.newaxis],
-            [90],
+            np.array([90.0]),
             xs,
-            [1.0],
+            np.array([1.0]),
         )
         g.set_subgrid(0, 0, 0, subgrid)
-        np.testing.assert_allclose(g.convolute_with_one(2212, lambda pid,x,q2: 0., lambda q2: 0.), [0.]*2)
-        np.testing.assert_allclose(g.convolute_with_one(2212, lambda pid,x,q2: 1, lambda q2: 1.), [5e6/9999,0.])
-        np.testing.assert_allclose(g.convolute_with_one(2212, lambda pid,x,q2: 1, lambda q2: 2.), [2**3 * 5e6/9999,0.])
+        np.testing.assert_allclose(
+            g.convolute_with_one(2212, lambda pid, x, q2: 0.0, lambda q2: 0.0),
+            np.array([0.0] * 2),
+        )
+        np.testing.assert_allclose(
+            g.convolute_with_one(2212, lambda pid, x, q2: 1, lambda q2: 1.0),
+            np.array([5e6 / 9999, 0.0]),
+        )
+        np.testing.assert_allclose(
+            g.convolute_with_one(2212, lambda pid, x, q2: 1, lambda q2: 2.0),
+            np.array([2 ** 3 * 5e6 / 9999, 0.0]),
+        )
 
     def test_axes(self):
         g = self.fake_grid()
@@ -105,17 +114,17 @@ class TestGrid:
         vs = np.random.rand(len(xs))
         subgrid = pineappl.import_only_subgrid.ImportOnlySubgridV1(
             vs[np.newaxis, :, np.newaxis],
-            [90.],
+            np.array([90.0]),
             xs,
-            [1.0],
+            np.array([1.0]),
         )
         g.set_subgrid(0, 0, 0, subgrid)
         vs2 = np.random.rand(len(xs))
         subgrid = pineappl.import_only_subgrid.ImportOnlySubgridV1(
             vs2[np.newaxis, :, np.newaxis],
-            [100.],
+            np.array([100.0]),
             xs,
-            [1.0],
+            np.array([1.0]),
         )
         g.set_subgrid(0, 1, 0, subgrid)
         # now get the thing
@@ -123,7 +132,7 @@ class TestGrid:
 
         np.testing.assert_allclose(ei[0], xs)
         np.testing.assert_allclose(ei[1], [])
-        np.testing.assert_allclose(ei[2], [90., 100.])
+        np.testing.assert_allclose(ei[2], [90.0, 100.0])
 
     def test_io(self, tmp_path):
         g = self.fake_grid()
@@ -136,18 +145,13 @@ class TestGrid:
     def test_convolute_eko(self):
         g = self.fake_grid()
         fake_eko = {
-            "q2_ref": 1.,
+            "q2_ref": 1.0,
             "targetpids": [1],
-            "targetgrid": [.1,1.],
+            "targetgrid": [0.1, 1.0],
             "inputpids": [1],
-            "inputgrid": [.1,1.],
-            "interpolation_xgrid": [.1,1.],
-            "Q2grid": {
-                90: {
-                    "operators": np.random.rand(1,2,1,2),
-                    "alphas": 1.
-                }
-            }
+            "inputgrid": [0.1, 1.0],
+            "interpolation_xgrid": [0.1, 1.0],
+            "Q2grid": {90: {"operators": np.random.rand(1, 2, 1, 2), "alphas": 1.0}},
         }
         g.set_key_value("lumi_id_types", "pdg_mc_ids")
         fk = g.convolute_eko(fake_eko)


### PR DESCRIPTION
This should close #82 

- [x] `import_only_subgrid`
- [x] `fk_table`
- [x] `bin`
- [x] update pure python package for breaking changes ([`convolute_eko`](https://github.com/N3PDF/pineappl/blob/3edf25ee8540a0141bb43425d47a24939fa21634/pineappl_py/src/grid.rs#L332))
- [x] update docs (lists are specified, should be arrays)
- [x] fix tests

I don't believe there is an automatic list to array conversion, so we might need to update also some other code after this (hopefully most is done in the pure python layer).

For this reason, I'm not using arrays where lists are expected. E.g. list of tuples won't be generate as 2 dimensional arrays in most cases:
https://github.com/N3PDF/pineappl/blob/3edf25ee8540a0141bb43425d47a24939fa21634/pineappl_py/src/grid.rs#L275
or lists of objects:
https://github.com/N3PDF/pineappl/blob/3edf25ee8540a0141bb43425d47a24939fa21634/pineappl_py/src/grid.rs#L69

I broke backward compatibility to pass an actual 5 dimensional array as operator, instead of splitting it in flattened + shape.

Most likely we want other updates before merging:
- `Vec`s were used not only in the interface, but even internally, like
  https://github.com/N3PDF/pineappl/blob/c0144e4505fda1f4a835d3a0428b4acefe371197/pineappl/src/grid.rs#L355-L362
  but since we're getting them from python as arrays, and in general arrays are more powerful and suitable for algebra, we might want to keep them as arrays, instead of the ugly conversion that I put at the moment
  https://github.com/N3PDF/pineappl/blob/3edf25ee8540a0141bb43425d47a24939fa21634/pineappl_py/src/grid.rs#L336-L349