### PR TITLE
Extend fill grid python interface

### DIFF
--- a/pineappl_py/src/grid.rs
+++ b/pineappl_py/src/grid.rs
@@ -7,7 +7,7 @@ use super::lumi::PyLumiEntry;
 use super::subgrid::{PySubgridEnum, PySubgridParams};
 
 use ndarray::{Array, Ix5};
-use numpy::{IntoPyArray, PyArray1, PyReadonlyArray2};
+use numpy::{IntoPyArray, PyArray1, PyReadonlyArray1, PyReadonlyArray2};
 
 use std::collections::HashMap;
 use std::fs::File;
@@ -146,7 +146,17 @@ impl PyGrid {
     /// Add an array to the grid.
     ///
     /// Useful to avoid multiple python calls, leading to performance improvement.
-    // TODO: signature
+    ///
+    /// Parameters
+    /// ----------
+    ///     ntuples : np.array(float)
+    ///         2 dimensional (4, N) array, made of `(x1, x2, q2, weight)` "ntuples"
+    ///     order : int
+    ///         order index
+    ///     observable : float
+    ///         reference point (to be binned)
+    ///     lumi : int
+    ///         luminosity index
     pub fn fill_with_array(
         &mut self,
         ntuples: PyReadonlyArray2<f64>,
@@ -166,7 +176,21 @@ impl PyGrid {
     }
 
     /// Add a point to the grid for all lumis.
-    // TODO: signature
+    ///
+    /// Parameters
+    /// ----------
+    ///     x1 : float
+    ///         first momentum fraction
+    ///     x2 : float
+    ///         second momentum fraction
+    ///     q2 : float
+    ///         process scale
+    ///     order : int
+    ///         order index
+    ///     observable : float
+    ///         reference point (to be binned)
+    ///     weights : np.array(float)
+    ///         cross section weights, one for each lumi
     pub fn fill_all(
         &mut self,
         x1: f64,
@@ -174,7 +198,7 @@ impl PyGrid {
         q2: f64,
         order: usize,
         observable: f64,
-        weights: Vec<f64>,
+        weights: PyReadonlyArray1<f64>,
     ) {
         self.grid.fill_all(
             order,
@@ -185,7 +209,7 @@ impl PyGrid {
                 q2,
                 weight: (),
             },
-            &weights,
+            &weights.to_vec().unwrap(),
         );
     }
 

--- a/pineappl_py/src/grid.rs
+++ b/pineappl_py/src/grid.rs
@@ -7,7 +7,7 @@ use super::lumi::PyLumiEntry;
 use super::subgrid::{PySubgridEnum, PySubgridParams};
 
 use ndarray::{Array, Ix5};
-use numpy::{IntoPyArray, PyArray1};
+use numpy::{IntoPyArray, PyArray1, PyReadonlyArray2};
 
 use std::collections::HashMap;
 use std::fs::File;
@@ -140,6 +140,52 @@ impl PyGrid {
             observable,
             lumi,
             &Ntuple::<f64> { x1, x2, q2, weight },
+        );
+    }
+
+    /// Add an array to the grid.
+    ///
+    /// Useful to avoid multiple python calls, leading to performance improvement.
+    // TODO: signature
+    pub fn fill_with_array(
+        &mut self,
+        ntuples: PyReadonlyArray2<f64>,
+        order: usize,
+        observable: f64,
+        lumi: usize,
+    ) {
+        for nt in ntuples.as_array().outer_iter() {
+            let (x1, x2, q2, weight) = (nt[0], nt[1], nt[2], nt[3]);
+            self.grid.fill(
+                order,
+                observable,
+                lumi,
+                &Ntuple::<f64> { x1, x2, q2, weight },
+            );
+        }
+    }
+
+    /// Add a point to the grid for all lumis.
+    // TODO: signature
+    pub fn fill_all(
+        &mut self,
+        x1: f64,
+        x2: f64,
+        q2: f64,
+        order: usize,
+        observable: f64,
+        weights: Vec<f64>,
+    ) {
+        self.grid.fill_all(
+            order,
+            observable,
+            &Ntuple::<()> {
+                x1,
+                x2,
+                q2,
+                weight: (),
+            },
+            &weights,
         );
     }
 

--- a/pineappl_py/src/grid.rs
+++ b/pineappl_py/src/grid.rs
@@ -6,8 +6,9 @@ use super::fk_table::PyFkTable;
 use super::lumi::PyLumiEntry;
 use super::subgrid::{PySubgridEnum, PySubgridParams};
 
+use itertools::izip;
 use ndarray::{Array, Ix5};
-use numpy::{IntoPyArray, PyArray1, PyReadonlyArray1, PyReadonlyArray2};
+use numpy::{IntoPyArray, PyArray1, PyReadonlyArray1};
 
 use std::collections::HashMap;
 use std::fs::File;
@@ -157,15 +158,23 @@ impl PyGrid {
     ///         reference point (to be binned)
     ///     lumi : int
     ///         luminosity index
-    pub fn fill_with_array(
+    pub fn fill_array(
         &mut self,
-        ntuples: PyReadonlyArray2<f64>,
+        x1s: PyReadonlyArray1<f64>,
+        x2s: PyReadonlyArray1<f64>,
+        q2s: PyReadonlyArray1<f64>,
         order: usize,
-        observable: f64,
+        observables: PyReadonlyArray1<f64>,
         lumi: usize,
+        weights: PyReadonlyArray1<f64>,
     ) {
-        for nt in ntuples.as_array().outer_iter() {
-            let (x1, x2, q2, weight) = (nt[0], nt[1], nt[2], nt[3]);
+        for (&x1, &x2, &q2, &observable, &weight) in izip!(
+            x1s.iter().unwrap(),
+            x2s.iter().unwrap(),
+            q2s.iter().unwrap(),
+            observables.iter().unwrap(),
+            weights.iter().unwrap(),
+        ) {
             self.grid.fill(
                 order,
                 observable,

--- a/pineappl_py/tests/test_grid.py
+++ b/pineappl_py/tests/test_grid.py
@@ -1,6 +1,7 @@
 import pineappl
 
 import numpy as np
+import pytest
 
 
 class TestOrder:
@@ -103,7 +104,7 @@ class TestGrid:
         )
         np.testing.assert_allclose(
             g.convolute_with_one(2212, lambda pid, x, q2: 1, lambda q2: 2.0),
-            [2 ** 3 * 5e6 / 9999, 0.0],
+            [2**3 * 5e6 / 9999, 0.0],
         )
 
     def test_axes(self):
@@ -160,7 +161,9 @@ class TestGrid:
 
     def test_fill(self):
         g = self.fake_grid()
-        g.fill(1.0, 1.0, 1.0, 0, 1e-2, 0, 10.0)
+        g.fill(0.5, 0.5, 10.0, 0, 0.01, 0, 10.0)
+        res = g.convolute_with_one(2212, lambda pid, x, q2: x, lambda q2: 1.0)
+        pytest.approx(res) == 0.0
 
     def test_fill_array(self):
         g = self.fake_grid()
@@ -173,7 +176,11 @@ class TestGrid:
             0,
             np.array([10.0, 100.0]),
         )
+        res = g.convolute_with_one(2212, lambda pid, x, q2: x, lambda q2: 1.0)
+        pytest.approx(res) == 0.0
 
     def test_fill_all(self):
         g = self.fake_grid()
         g.fill_all(1.0, 1.0, 1.0, 0, 1e-2, np.array([10.0]))
+        res = g.convolute_with_one(2212, lambda pid, x, q2: x, lambda q2: 1.0)
+        pytest.approx(res) == 0.0

--- a/pineappl_py/tests/test_grid.py
+++ b/pineappl_py/tests/test_grid.py
@@ -28,7 +28,7 @@ class TestGrid:
         assert isinstance(g.raw, pineappl.pineappl.PyGrid)
         # orders
         assert len(g.orders()) == 1
-        assert g.orders()[0].as_tuple() == (3,0,0,0)
+        assert g.orders()[0].as_tuple() == (3, 0, 0, 0)
 
     def test_set_subgrid(self):
         g = self.fake_grid()
@@ -57,28 +57,28 @@ class TestGrid:
     def test_set_key_value(self):
         g = self.fake_grid()
         g.set_key_value("bla", "blub")
-        g.set_key_value("\"", "'")
+        g.set_key_value('"', "'")
         g.set_key_value("äöü", "ß\\")
 
     def test_bins(self):
         g = self.fake_grid()
         # 1D
         normalizations = [1.0] * 2
-        limits = [(1,1),(2,2)]
+        limits = [(1, 1), (2, 2)]
         remapper = pineappl.bin.BinRemapper(normalizations, limits)
         g.set_remapper(remapper)
         assert g.bin_dimensions() == 1
-        np.testing.assert_allclose(g.bin_left(0), [1,2])
-        np.testing.assert_allclose(g.bin_right(0), [1,2])
+        np.testing.assert_allclose(g.bin_left(0), [1, 2])
+        np.testing.assert_allclose(g.bin_right(0), [1, 2])
         # 2D
-        limits = [(1,2),(2,3),(2,4),(3,5)]
+        limits = [(1, 2), (2, 3), (2, 4), (3, 5)]
         remapper = pineappl.bin.BinRemapper(normalizations, limits)
         g.set_remapper(remapper)
         assert g.bin_dimensions() == 2
-        np.testing.assert_allclose(g.bin_left(0), [1,2])
-        np.testing.assert_allclose(g.bin_right(0), [2,4])
-        np.testing.assert_allclose(g.bin_left(1), [2,3])
-        np.testing.assert_allclose(g.bin_right(1), [3,5])
+        np.testing.assert_allclose(g.bin_left(0), [1, 2])
+        np.testing.assert_allclose(g.bin_right(0), [2, 4])
+        np.testing.assert_allclose(g.bin_left(1), [2, 3])
+        np.testing.assert_allclose(g.bin_right(1), [3, 5])
 
     def test_convolute_with_one(self):
         g = self.fake_grid()
@@ -93,9 +93,18 @@ class TestGrid:
             [1.0],
         )
         g.set_subgrid(0, 0, 0, subgrid)
-        np.testing.assert_allclose(g.convolute_with_one(2212, lambda pid,x,q2: 0., lambda q2: 0.), [0.]*2)
-        np.testing.assert_allclose(g.convolute_with_one(2212, lambda pid,x,q2: 1, lambda q2: 1.), [5e6/9999,0.])
-        np.testing.assert_allclose(g.convolute_with_one(2212, lambda pid,x,q2: 1, lambda q2: 2.), [2**3 * 5e6/9999,0.])
+        np.testing.assert_allclose(
+            g.convolute_with_one(2212, lambda pid, x, q2: 0.0, lambda q2: 0.0),
+            [0.0] * 2,
+        )
+        np.testing.assert_allclose(
+            g.convolute_with_one(2212, lambda pid, x, q2: 1, lambda q2: 1.0),
+            [5e6 / 9999, 0.0],
+        )
+        np.testing.assert_allclose(
+            g.convolute_with_one(2212, lambda pid, x, q2: 1, lambda q2: 2.0),
+            [2 ** 3 * 5e6 / 9999, 0.0],
+        )
 
     def test_axes(self):
         g = self.fake_grid()
@@ -105,7 +114,7 @@ class TestGrid:
         vs = np.random.rand(len(xs))
         subgrid = pineappl.import_only_subgrid.ImportOnlySubgridV1(
             vs[np.newaxis, :, np.newaxis],
-            [90.],
+            [90.0],
             xs,
             [1.0],
         )
@@ -113,7 +122,7 @@ class TestGrid:
         vs2 = np.random.rand(len(xs))
         subgrid = pineappl.import_only_subgrid.ImportOnlySubgridV1(
             vs2[np.newaxis, :, np.newaxis],
-            [100.],
+            [100.0],
             xs,
             [1.0],
         )
@@ -123,7 +132,7 @@ class TestGrid:
 
         np.testing.assert_allclose(ei[0], xs)
         np.testing.assert_allclose(ei[1], [])
-        np.testing.assert_allclose(ei[2], [90., 100.])
+        np.testing.assert_allclose(ei[2], [90.0, 100.0])
 
     def test_io(self, tmp_path):
         g = self.fake_grid()
@@ -136,19 +145,34 @@ class TestGrid:
     def test_convolute_eko(self):
         g = self.fake_grid()
         fake_eko = {
-            "q2_ref": 1.,
+            "q2_ref": 1.0,
             "targetpids": [1],
-            "targetgrid": [.1,1.],
+            "targetgrid": [0.1, 1.0],
             "inputpids": [1],
-            "inputgrid": [.1,1.],
-            "interpolation_xgrid": [.1,1.],
-            "Q2grid": {
-                90: {
-                    "operators": np.random.rand(1,2,1,2),
-                    "alphas": 1.
-                }
-            }
+            "inputgrid": [0.1, 1.0],
+            "interpolation_xgrid": [0.1, 1.0],
+            "Q2grid": {90: {"operators": np.random.rand(1, 2, 1, 2), "alphas": 1.0}},
         }
         g.set_key_value("lumi_id_types", "pdg_mc_ids")
         fk = g.convolute_eko(fake_eko)
         assert isinstance(fk.raw, pineappl.pineappl.PyFkTable)
+
+    def test_fill(self):
+        g = self.fake_grid()
+        g.fill(1.0, 1.0, 1.0, 0, 1e-2, 0, 10.0)
+
+    def test_fill_array(self):
+        g = self.fake_grid()
+        g.fill_array(
+            np.array([0.5, 1.0]),
+            np.array([0.5, 1.0]),
+            np.array([0.5, 1.0]),
+            0,
+            np.array([1e-3, 1e-2]),
+            0,
+            np.array([10.0, 100.0]),
+        )
+
+    def test_fill_all(self):
+        g = self.fake_grid()
+        g.fill_all(1.0, 1.0, 1.0, 0, 1e-2, np.array([10.0]))


### PR DESCRIPTION
This should close #81 

- [x] docs
- [x] test

I'm not sure that getting as input a **2 dimensional `numpy` array** is the best idea ever:
https://github.com/N3PDF/pineappl/blob/cf7a8828e73d77a8e4b0c9a05a369617932e95d2/pineappl_py/src/grid.rs#L150-L156
but at the end of the day `NTuple` is a meaningful concept in `pineappl`, and it is more or less a named array of `f64` elements, so it's not that bad.
The only other option would be to have **4 matching arrays** `x1s`, `x2s`, `q2s`, `weights`:
- *advantage*: things are named, no confusion about sorting
- *disadvantage*: it's messier, and you want them to match, that is something intrinsic to a 2 dimensional array