### PR TITLE
`convolute_eko`: `x2_grid` was determined though not needed

### DIFF
--- a/pineappl/src/grid.rs
+++ b/pineappl/src/grid.rs
@@ -1535,30 +1535,38 @@ impl Grid {
             .find(|subgrid| !subgrid.is_empty())
             .unwrap_or_else(|| unreachable!());
         // source x1/x2 grid might differ and be differently sorted than the operator
-        let x1_grid: Vec<_> = first_non_zero_grid
-            .x1_grid()
-            .iter()
-            .map(|x| {
-                eko_info
-                    .grid_axes
-                    .x_grid
-                    .iter()
-                    .position(|xi| approx_eq!(f64, *xi, *x, ulps = 64))
-                    .unwrap_or_else(|| unreachable!())
-            })
-            .collect();
-        let x2_grid: Vec<_> = first_non_zero_grid
-            .x2_grid()
-            .iter()
-            .map(|x| {
-                eko_info
-                    .grid_axes
-                    .x_grid
-                    .iter()
-                    .position(|xi| approx_eq!(f64, *xi, *x, ulps = 64))
-                    .unwrap_or_else(|| unreachable!())
-            })
-            .collect();
+        let x1_grid: Vec<_> = if has_pdf1 {
+            first_non_zero_grid
+                .x1_grid()
+                .iter()
+                .map(|x| {
+                    eko_info
+                        .grid_axes
+                        .x_grid
+                        .iter()
+                        .position(|xi| approx_eq!(f64, *xi, *x, ulps = 64))
+                        .unwrap_or_else(|| unreachable!())
+                })
+                .collect()
+        } else {
+            Vec::<usize>::new()
+        };
+        let x2_grid: Vec<_> = if has_pdf2 {
+            first_non_zero_grid
+                .x2_grid()
+                .iter()
+                .map(|x| {
+                    eko_info
+                        .grid_axes
+                        .x_grid
+                        .iter()
+                        .position(|xi| approx_eq!(f64, *xi, *x, ulps = 64))
+                        .unwrap_or_else(|| unreachable!())
+                })
+                .collect()
+        } else {
+            Vec::<usize>::new()
+        };
 
         // iterate over all bins, which are mapped one-to-one from the target to the source grid
         for bin in 0..self.bin_info().bins() {

--- a/pineappl/src/grid.rs
+++ b/pineappl/src/grid.rs
@@ -1535,7 +1535,7 @@ impl Grid {
             .find(|subgrid| !subgrid.is_empty())
             .unwrap_or_else(|| unreachable!());
         // source x1/x2 grid might differ and be differently sorted than the operator
-        let x1_grid: Vec<_> = if has_pdf1 {
+        let x1_grid = if has_pdf1 {
             first_non_zero_grid
                 .x1_grid()
                 .iter()
@@ -1549,9 +1549,9 @@ impl Grid {
                 })
                 .collect()
         } else {
-            Vec::<usize>::new()
+            Vec::new()
         };
-        let x2_grid: Vec<_> = if has_pdf2 {
+        let x2_grid = if has_pdf2 {
             first_non_zero_grid
                 .x2_grid()
                 .iter()
@@ -1565,7 +1565,7 @@ impl Grid {
                 })
                 .collect()
         } else {
-            Vec::<usize>::new()
+            Vec::new()
         };
 
         // iterate over all bins, which are mapped one-to-one from the target to the source grid


### PR DESCRIPTION
During the debug of https://github.com/NNPDF/runcards/pull/150 we realized there is a bug in PineAPPL `convolute_eko`:
`x2_grid` was determined although it was never needed (because x2 is trivial)

This fix adds a protection to the generation same as there is already for reading: https://github.com/N3PDF/pineappl/blob/04650d99dd52f7985ba4fb2a976980b2b91ce6e7/pineappl/src/grid.rs#L1632

the quickfix (applied in https://github.com/NNPDF/runcards/pull/150/commits/3a5b7c9dc053707bb74d181c69b5add50c5a385f ) is to point the trivial point to an existing point in the x1 grid - this is done also for DIS (and everything derived from that), specificly x2=1, which, by chance, is in the x1 grid; that's also the reason why it was not discovered before

there might be an other bug related: @scarlehoff @andreab1997  I couldn't trigger again the core dump - can you remind me, what do I need to do?