### PR TITLE
Distribute CLI as a Python package

### DIFF
--- a/pineappl_cli/pyproject.toml
+++ b/pineappl_cli/pyproject.toml
@@ -1,0 +1,29 @@
+[build-system]
+requires = ["maturin>=0.12,<0.13"]
+build-backend = "maturin"
+
+[project]
+name = "pineappl-cli"
+requires-python = ">=3.6"
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Intended Audience :: Science/Research",
+  "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
+  "Natural Language :: English",
+  "Operating System :: MacOS",
+  "Operating System :: Microsoft :: Windows",
+  "Operating System :: POSIX",
+  "Programming Language :: Rust",
+  "Topic :: Scientific/Engineering :: Physics",
+]
+
+dependencies = []
+
+[project.urls]
+homepage = "https://n3pdf.github.io/pineappl/"
+documentation = "https://pineappl.readthedocs.io/"
+changelog = "https://github.com/N3PDF/pineappl/blob/master/CHANGELOG.md"
+
+[tool.maturin]
+bindings = "bin"
+strip = true


### PR DESCRIPTION
The goal of this PR is just to add metadata for Python packaging.
No new crate/folder is going to be created, because no further code should be added.

To do:
- [x] add required metadata
- [ ] prepare CI for release
- [ ] add [dependency](https://github.com/N3PDF/pineappl/pull/176#issuecomment-1249179607) on this new package in the `pineappl` Python package

In order to test locally, you can use the usual:
- `maturin develop` to build and install in current environment
- `maturin build` to make the actual Python package, without installation

Eventually, we will use `maturin publish` (possibly in the same workflow distributing `pineappl_py`), and just upload the further package `pineappl-cli` to PyPI, just wrapping the Rust binary.
https://github.com/N3PDF/pineappl/blob/81dd719f62103895be245251af38582d05dca80b/.github/workflows/wheels.yml#L20
https://github.com/N3PDF/pineappl/blob/81dd719f62103895be245251af38582d05dca80b/.github/workflows/wheels.yml#L47